### PR TITLE
docs: minor tense reword on core-sv-042

### DIFF
--- a/core/core-sv-042.md
+++ b/core/core-sv-042.md
@@ -1,10 +1,11 @@
-# Nonce comparison takes too long to complete when fetching unconfirmed transactions to forge
+# Nonce comparison took too long to complete when fetching unconfirmed transactions to forge
 **Identifier:** Core-SV-042
 ## Cause:
-By continually filling the transaction pool with valid transactions, it will grow at a rate faster than the transactions in the pool can be consumed by forging blocks on the network. When it reaches a certain threshold (amount varies depending on node specification, but always before reaching the upper limit even on the most powerful nodes), the call to getUnconfirmedTransactions will time out due to the nonce comparison in sortAll() of memory.ts in the core-transaction-pool package.
+By continually filling the transaction pool with valid transactions, it will grow at a rate faster than the transactions in the pool can be consumed by forging blocks on the network. When it reached a certain threshold (amount varies depending on node specification, but always before reaching the upper limit even on the most powerful nodes), the call to getUnconfirmedTransactions would time out due to the nonce comparison in sortAll() of memory.ts in the core-transaction-pool package.
 >Reported by: [alessio](https://github.com/alessiodf)
 ## Solution
 **Patch:** https://github.com/ArkEcosystem/core/pull/3667
 ## Status
 Closed.
+
 **Release:** https://github.com/ArkEcosystem/core/releases/tag/2.6.34


### PR DESCRIPTION
## Summary

Tense reword because it's no longer vulnerable. All reports used the past tense for that reason.

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
